### PR TITLE
Common uboot with read configuration from file

### DIFF
--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -328,7 +328,7 @@ static uint8_t readID(void) {
         return 4;
     }
 
-    env_set("CONSOLE_VIDEO", "r61520fb5.ko");
+    env_set("CONSOLE_VIDEO", "r61520fb.ko");
     env_set("DETECTED_VERSION", "UNKNOWN");
     writeScreenReg = 0x2c;
     madctlCmd = 0xe0;


### PR DESCRIPTION
Common uboot with read configuration from file:
- read configuration from SD
- write configuration to SD
- add support to RM68090 controller

After boot, uboot reads config.cfg file to determine provided device. Next performs detection and writes information to uEnv.txt

example on sup m3:
CONSOLE_VARIANT=m3
CONSOLE_VIDEO=r61520fb.ko
DETECTED_VERSION=SUP M3 unknown controller Works with R61520
READID_0x04=00 98 51 01

example on v90:
CONSOLE_VARIANT=v90_q90
CONSOLE_VIDEO=st7789sfb.ko
DETECTED_VERSION=ST7789S controller
READID_0x04=00 85 85 52

if unable to detect, such information is also available in uEnv.txt
example:
CONSOLE_VARIANT=m3
CONSOLE_VIDEO=r61520fb.ko
DETECTED_VERSION=UNKNOWN
READID_0x04=00 11 11 11
READID_0x00=00 00 00 00