### PR TITLE
remove pgo builds in *.yml & update Actions to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,42 +40,6 @@ jobs:
         path: u-boot-sunxi-with-spl.bin
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
 
-  build-modern-pocketgo:
-    name: MiyooCFW U-Boot (musl libc) pocketgo
-    runs-on: ubuntu-20.04
-    container:
-      image: nfriedly/miyoo-toolchain:latest
-    steps:
-      - uses: actions/checkout@v2
-      # ARCH=arm and CROSS_COMPILE=arm-buildroot-linux-musleabi- env props are set in the docker image
-      - name: configure
-        run: make miyoo_pocketgo_defconfig
-      - name: build
-        run: make
-      - uses: actions/upload-artifact@v2
-        with:
-          name: MiyooCFW U-Boot pocketgo
-          path: u-boot-sunxi-with-spl.bin
-          if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-
-  build-legacy-pocketgo:
-    name: Legacy MiyooCFW U-Boot (uClibc) pocketgo
-    runs-on: ubuntu-20.04
-    container:
-      image: nfriedly/miyoo-toolchain:steward
-    steps:
-      - uses: actions/checkout@v2
-      # ARCH=arm and CROSS_COMPILE=arm-miyoo-linux-uclibcgnueabi- env props are set in the docker image
-      - name: configure
-        run: make miyoo_pocketgo_defconfig
-      - name: build
-        run: make
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Legacy MiyooCFW U-Boot pocketgo
-          path: u-boot-sunxi-with-spl.bin
-          if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-
   build-modern-1bit:
     name: MiyooCFW U-Boot (musl libc) 1bit
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ jobs:
     container:
       image: nfriedly/miyoo-toolchain:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # ARCH=arm and CROSS_COMPILE=arm-buildroot-linux-musleabi- env props are set in the docker image
     - name: configure
       run: make miyoo_defconfig 
     - name: build
       run: make
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: MiyooCFW U-Boot
         path: u-boot-sunxi-with-spl.bin
@@ -28,13 +28,13 @@ jobs:
     container:
       image: nfriedly/miyoo-toolchain:steward
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # ARCH=arm and CROSS_COMPILE=arm-miyoo-linux-uclibcgnueabi- env props are set in the docker image
     - name: configure
       run: make miyoo_defconfig 
     - name: build
       run: make
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Legacy MiyooCFW U-Boot
         path: u-boot-sunxi-with-spl.bin
@@ -46,13 +46,13 @@ jobs:
     container:
       image: nfriedly/miyoo-toolchain:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # ARCH=arm and CROSS_COMPILE=arm-buildroot-linux-musleabi- env props are set in the docker image
       - name: configure
         run: make miyoo_mmc_1bit_defconfig
       - name: build
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: MiyooCFW U-Boot 1bit
           path: u-boot-sunxi-with-spl.bin
@@ -64,13 +64,13 @@ jobs:
     container:
       image: nfriedly/miyoo-toolchain:steward
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # ARCH=arm and CROSS_COMPILE=arm-miyoo-linux-uclibcgnueabi- env props are set in the docker image
       - name: configure
         run: make miyoo_mmc_1bit_defconfig
       - name: build
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Legacy MiyooCFW U-Boot 1bit
           path: u-boot-sunxi-with-spl.bin


### PR DESCRIPTION
We use only ``miyoo_defconfig`` for all 4-bit bus consoles now (common uboot).