### PR TITLE
read console.cfg with -r option in env imp

### DIFF
--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -156,7 +156,7 @@ static uint8_t readID(void) {
 
     //Get configuration from SD
     run_command("fatload mmc 0:1 0x81000000 console.cfg", 0);
-    run_command("env import -t 0x81000000 0x20000", 0);
+    run_command("env import -tr 0x81000000 0x20000", 0);
     console_variant = env_get("CONSOLE_VARIANT");
 
     //Read register 0x00


### PR DESCRIPTION
Translate any CRLF to LF in ``console.cfg`` file, thus '\r' are ignored in imported variable.

You have to place blank line after CONSOLE_VARIANT, otherwise it will still fail to write correctly variant to uEnv.txt if editing program writes EOL's in Windows (CR LF) format.

<https://lists.denx.de/pipermail/u-boot/2014-July/183704.html>