### PR TITLE
[SUNXI] refactor readID variants

### DIFF
--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -159,46 +159,6 @@ static uint8_t readID(void) {
     run_command("env import -tr 0x81000000 0x20000", 0);
     console_variant = env_get("CONSOLE_VARIANT");
 
-    //Read register 0x00
-    lcd_wr_cmd(0x00);
-    tmp[0] = lcd_rd_dat();
-    for (x = 0; x < 4; x++) {
-        tmp[x] = lcd_rd_dat() >> 1;
-    }
-    ver[0]=tmp[3];
-    ver[1]=tmp[0];
-    ver[2]=tmp[1];
-    ver[3]=tmp[2];
-    char buffer0[50];
-    snprintf(buffer0, sizeof(buffer0), "%02x %02x %02x %02x", ver[0], ver[1], ver[2], ver[3]);
-    env_set("READID_0x00", buffer0);
-
-    if ((ver[3] == 0x6809) || (ver[3] == 0x5009)) { // SUP M3 with RM68090 TFT controller
-        env_set("CONSOLE_VIDEO", "rm68090fb.ko");
-        env_set("CONSOLE_PARAMETERS", "");
-        env_set("DETECTED_VERSION", "RM68090 controller");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
-        writeScreenReg = 0x22;
-        return 5;
-    }
-
-    lcd_wr_cmd(0xB0);
-    lcd_wr_dat(0x0000); // this is needed to unlock the R61520
-
-    //Read register 0x04
-    lcd_wr_cmd(0x04);
-    tmp[0] = lcd_rd_dat();
-    for (x = 0; x < 4; x++) {
-        tmp[x] = lcd_rd_dat() >> 1;
-    }
-    ver[0]=tmp[3];
-    ver[1]=tmp[0];
-    ver[2]=tmp[1];
-    ver[3]=tmp[2];
-    char buffer[50];
-    snprintf(buffer, sizeof(buffer), "%02x %02x %02x %02x", ver[0], ver[1], ver[2], ver[3]);
-    env_set("READID_0x04", buffer);
-
    // force configuration from SD in console.cfg
     if (console_variant && !strcmp(console_variant, "bittboy2x_v1")) {
         env_set("CONSOLE_VIDEO", "r61520fb.ko");
@@ -318,6 +278,46 @@ static uint8_t readID(void) {
     }
 
    // Autodetection method if no valid CONSOLE_VARIANT provided within cnofiguration file in SD
+    //Read register 0x00
+    lcd_wr_cmd(0x00);
+    tmp[0] = lcd_rd_dat();
+    for (x = 0; x < 4; x++) {
+        tmp[x] = lcd_rd_dat() >> 1;
+    }
+    ver[0]=tmp[3];
+    ver[1]=tmp[0];
+    ver[2]=tmp[1];
+    ver[3]=tmp[2];
+    char buffer0[50];
+    snprintf(buffer0, sizeof(buffer0), "%02x %02x %02x %02x", ver[0], ver[1], ver[2], ver[3]);
+    env_set("READID_0x00", buffer0);
+
+    if ((ver[3] == 0x6809) || (ver[3] == 0x5009)) { // SUP M3 with RM68090 TFT controller
+        env_set("CONSOLE_VIDEO", "rm68090fb.ko");
+        env_set("CONSOLE_PARAMETERS", "");
+        env_set("DETECTED_VERSION", "RM68090 controller");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
+        writeScreenReg = 0x22;
+        return 5;
+    }
+
+    lcd_wr_cmd(0xB0);
+    lcd_wr_dat(0x0000); // this is needed to unlock the R61520
+
+    //Read register 0x04
+    lcd_wr_cmd(0x04);
+    tmp[0] = lcd_rd_dat();
+    for (x = 0; x < 4; x++) {
+        tmp[x] = lcd_rd_dat() >> 1;
+    }
+    ver[0]=tmp[3];
+    ver[1]=tmp[0];
+    ver[2]=tmp[1];
+    ver[3]=tmp[2];
+    char buffer[50];
+    snprintf(buffer, sizeof(buffer), "%02x %02x %02x %02x", ver[0], ver[1], ver[2], ver[3]);
+    env_set("READID_0x04", buffer);
+
     if ((ver[1] == 0x22) && (ver[2] == 0x15) && (ver[3] == 0x20)) { // R61520 controller
         env_set("CONSOLE_VIDEO", "r61520fb.ko");
         env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");

--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -199,111 +199,8 @@ static uint8_t readID(void) {
     snprintf(buffer, sizeof(buffer), "%02x %02x %02x %02x", ver[0], ver[1], ver[2], ver[3]);
     env_set("READID_0x04", buffer);
 
-    if ((ver[1] == 0x22) && (ver[2] == 0x15) && (ver[3] == 0x20)) { // R61520 controller
-        env_set("CONSOLE_VIDEO", "r61520fb.ko");
-        env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
-        env_set("DETECTED_VERSION", "R61520 controller");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-        madctlCmd = 0xe0;
-        invert = 0x20;
-        writeScreenReg = 0x2c;
-        return 1;
-    }
-    if ((ver[1] == 0x85) && (ver[2] == 0x85) && (ver[3] == 0x52)) { // ST7789S controller
-        if (console_variant && !strcmp(console_variant, "bittboy2x_v1")) { //bb2x
-            madctlCmd = 0xe0;
-            invert = 0x20;
-            writeScreenReg = 0x2c;
-            env_set("CONSOLE_VIDEO", "r61520fb.ko");
-            env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
-            env_set("DETECTED_VERSION", "bittboy2x_v1 r61520fb controller");
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
-            return 1;
-        }
-        miyoo_ver = 2;
-        if ((console_variant && !strcmp(console_variant, "bittboy3.5")) || (console_variant && !strcmp(console_variant, "bittboy2x_v2"))) {
-            madctlCmd = 0x70;
-            env_set("DETECTED_VERSION", "bittboy3.5/bittboy2x_v2 ST7789S controller");
-            env_set("CONSOLE_PARAMETERS", "lowcurrent=1 flip=1");
-            if (!strcmp(console_variant, "bittboy3.5"))
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
-            else
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
-        }
-        else {
-            madctlCmd = 0xB0;
-            env_set("DETECTED_VERSION", "V90/Q90/Q20/PocketGo ST7789S controller");
-            env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
-            if (!strcmp(console_variant, "q20") || !strcmp(console_variant, "q90"))
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-            else if (!strcmp(console_variant, "v90"))
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=5 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-            else
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-        }
-        invert = 0x20;
-        writeScreenReg = 0x2c;
-        if (console_variant && !strcmp(console_variant, "pocketgo_TE"))
-            env_set("CONSOLE_VIDEO", "st7789sTEfb.ko");
-        else
-            env_set("CONSOLE_VIDEO", "st7789sfb.ko");
 
-        return 2;
-
-    }
-    if ((ver[2] == 0xC5) && (ver[3] == 0x05)) { // R61505W controller
-        env_set("CONSOLE_VIDEO", "r61520fb.ko");
-        env_set("CONSOLE_PARAMETERS", "version=3");
-        env_set("DETECTED_VERSION", "R61505W controller");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-        madctlCmd = 0xB0;
-        invert = 0x20;
-        writeScreenReg = 0x2c;
-        return 3;
-    }
-    if ((ver[2] == 0x93) && (ver[3] == 0x06)) { // GC9306 controller
-        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
-        env_set("CONSOLE_PARAMETERS", "");
-        env_set("DETECTED_VERSION", "GC9306 controller");
-        if (!strcmp(console_variant, "xyc"))
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
-        else
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2");
-        writeScreenReg = 0x2c;
-        return 4;
-    }
-    if ((ver[2] == 0x93) && (ver[3] == 0x05)) { // GC9305 controller
-        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
-        env_set("CONSOLE_PARAMETERS", "");
-        env_set("DETECTED_VERSION", "GC9305 controller");
-        if (!strcmp(console_variant, "xyc"))
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
-        else
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2");
-        writeScreenReg = 0x2c;
-        return 4;
-    }
-    if ((ver[0] == 0x00) && (ver[1] == 0x98) && (ver[2] == 0x51) && (ver[3] == 0x01)) { // SUP M3 unknown controller Works with R61520.
-        env_set("CONSOLE_VIDEO", "r61520fb.ko");
-        env_set("CONSOLE_PARAMETERS", "version=1 flip=1 invert=1 lowcurrent=1");
-        env_set("DETECTED_VERSION", "SUP M3 unknown controller Works with R61520");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
-        madctlCmd = 0x38;
-        invert = 0x21;
-        writeScreenReg = 0x2c;
-        return 1;
-    }
-    if ((ver[0] == 0x00) && (ver[1] == 0x80) && (ver[2] == 0x00)) { // SUP M3 with HX8347-D
-        env_set("CONSOLE_VIDEO", "hx8347dfb.ko");
-        env_set("CONSOLE_PARAMETERS", "");
-        env_set("DETECTED_VERSION", "HX8347-D controller");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
-        writeScreenReg = 0x22;
-        return 6;
-    }
-
-   // default configuration from SD
-
+   // force configuration from SD in console.cfg
     if (console_variant && !strcmp(console_variant, "bittboy2x_v1")) {
         env_set("CONSOLE_VIDEO", "r61520fb.ko");
         env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
@@ -411,6 +308,108 @@ static uint8_t readID(void) {
         env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
         writeScreenReg = 0x2c;
         return 4;
+    }
+
+   // Autodetection method if no valid CONSOLE_VARIANT provided within cnofiguration file in SD
+    if ((ver[1] == 0x22) && (ver[2] == 0x15) && (ver[3] == 0x20)) { // R61520 controller
+        env_set("CONSOLE_VIDEO", "r61520fb.ko");
+        env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
+        env_set("DETECTED_VERSION", "R61520 controller");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+        madctlCmd = 0xe0;
+        invert = 0x20;
+        writeScreenReg = 0x2c;
+        return 1;
+    }
+    if ((ver[1] == 0x85) && (ver[2] == 0x85) && (ver[3] == 0x52)) { // ST7789S controller
+        if (console_variant && !strcmp(console_variant, "bittboy2x_v1")) { //bb2x
+            madctlCmd = 0xe0;
+            invert = 0x20;
+            writeScreenReg = 0x2c;
+            env_set("CONSOLE_VIDEO", "r61520fb.ko");
+            env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
+            env_set("DETECTED_VERSION", "bittboy2x_v1 r61520fb controller");
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
+            return 1;
+        }
+        miyoo_ver = 2;
+        if ((console_variant && !strcmp(console_variant, "bittboy3.5")) || (console_variant && !strcmp(console_variant, "bittboy2x_v2"))) {
+            madctlCmd = 0x70;
+            env_set("DETECTED_VERSION", "bittboy3.5/bittboy2x_v2 ST7789S controller");
+            env_set("CONSOLE_PARAMETERS", "lowcurrent=1 flip=1");
+            if (!strcmp(console_variant, "bittboy3.5"))
+                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
+            else
+                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
+        }
+        else {
+            madctlCmd = 0xB0;
+            env_set("DETECTED_VERSION", "V90/Q90/Q20/PocketGo ST7789S controller");
+            env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
+            if (!strcmp(console_variant, "q20") || !strcmp(console_variant, "q90"))
+                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+            else if (!strcmp(console_variant, "v90"))
+                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=5 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+            else
+                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+        }
+        invert = 0x20;
+        writeScreenReg = 0x2c;
+        if (console_variant && !strcmp(console_variant, "pocketgo_TE"))
+            env_set("CONSOLE_VIDEO", "st7789sTEfb.ko");
+        else
+            env_set("CONSOLE_VIDEO", "st7789sfb.ko");
+        return 2;
+    }
+    if ((ver[2] == 0xC5) && (ver[3] == 0x05)) { // R61505W controller
+        env_set("CONSOLE_VIDEO", "r61520fb.ko");
+        env_set("CONSOLE_PARAMETERS", "version=3");
+        env_set("DETECTED_VERSION", "R61505W controller");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+        madctlCmd = 0xB0;
+        invert = 0x20;
+        writeScreenReg = 0x2c;
+        return 3;
+    }
+    if ((ver[2] == 0x93) && (ver[3] == 0x06)) { // GC9306 controller
+        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
+        env_set("CONSOLE_PARAMETERS", "");
+        env_set("DETECTED_VERSION", "GC9306 controller");
+        if (!strcmp(console_variant, "xyc"))
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
+        else
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2");
+        writeScreenReg = 0x2c;
+        return 4;
+    }
+    if ((ver[2] == 0x93) && (ver[3] == 0x05)) { // GC9305 controller
+        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
+        env_set("CONSOLE_PARAMETERS", "");
+        env_set("DETECTED_VERSION", "GC9305 controller");
+        if (!strcmp(console_variant, "xyc"))
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
+        else
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2");
+        writeScreenReg = 0x2c;
+        return 4;
+    }
+    if ((ver[0] == 0x00) && (ver[1] == 0x98) && (ver[2] == 0x51) && (ver[3] == 0x01)) { // SUP M3 unknown controller Works with R61520.
+        env_set("CONSOLE_VIDEO", "r61520fb.ko");
+        env_set("CONSOLE_PARAMETERS", "version=1 flip=1 invert=1 lowcurrent=1");
+        env_set("DETECTED_VERSION", "SUP M3 unknown controller Works with R61520");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
+        madctlCmd = 0x38;
+        invert = 0x21;
+        writeScreenReg = 0x2c;
+        return 1;
+    }
+    if ((ver[0] == 0x00) && (ver[1] == 0x80) && (ver[2] == 0x00)) { // SUP M3 with HX8347-D
+        env_set("CONSOLE_VIDEO", "hx8347dfb.ko");
+        env_set("CONSOLE_PARAMETERS", "");
+        env_set("DETECTED_VERSION", "HX8347-D controller");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
+        writeScreenReg = 0x22;
+        return 6;
     }
 
     env_set("CONSOLE_VIDEO", "r61520fb.ko");

--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -256,6 +256,14 @@ static uint8_t readID(void) {
         writeScreenReg = 0x22;
         return 6;
     }
+    if (console_variant && !strcmp(console_variant, "m3_gc9306")) {
+        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
+        env_set("CONSOLE_PARAMETERS", "");
+        env_set("FORCE_VERSION", "m3_gc9306");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
+        writeScreenReg = 0x2c;
+        return 4;
+    }
     if (console_variant && !strcmp(console_variant, "xyc")) {
         env_set("CONSOLE_VIDEO", "gc9306fb.ko");
         env_set("CONSOLE_PARAMETERS", "");
@@ -377,7 +385,7 @@ static uint8_t readID(void) {
         if (!strcmp(console_variant, "xyc"))
             env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
         else
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2");
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
         writeScreenReg = 0x2c;
         return 4;
     }
@@ -388,7 +396,7 @@ static uint8_t readID(void) {
         if (!strcmp(console_variant, "xyc"))
             env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
         else
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2");
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
         writeScreenReg = 0x2c;
         return 4;
     }

--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -199,7 +199,6 @@ static uint8_t readID(void) {
     snprintf(buffer, sizeof(buffer), "%02x %02x %02x %02x", ver[0], ver[1], ver[2], ver[3]);
     env_set("READID_0x04", buffer);
 
-
    // force configuration from SD in console.cfg
     if (console_variant && !strcmp(console_variant, "bittboy2x_v1")) {
         env_set("CONSOLE_VIDEO", "r61520fb.ko");
@@ -257,6 +256,14 @@ static uint8_t readID(void) {
         writeScreenReg = 0x22;
         return 6;
     }
+    if (console_variant && !strcmp(console_variant, "xyc")) {
+        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
+        env_set("CONSOLE_PARAMETERS", "");
+        env_set("FORCE_VERSION", "xyc");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
+        writeScreenReg = 0x2c;
+        return 4;
+    }
     if (console_variant && !strcmp(console_variant, "pocketgo_TE")) {
         env_set("CONSOLE_VIDEO", "st7789sTEfb.ko");
         env_set("CONSOLE_PARAMETERS", "");
@@ -270,11 +277,11 @@ static uint8_t readID(void) {
     if (console_variant && (!strcmp(console_variant, "q20") || !strcmp(console_variant, "q90"))) {
         env_set("CONSOLE_VIDEO", "st7789sfb.ko");
         env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
-    	if (console_variant && !strcmp(console_variant, "q20")) {
-		env_set("FORCE_VERSION", "q20");
-	} else {
-		env_set("FORCE_VERSION", "q90");
-	}
+        if (console_variant && !strcmp(console_variant, "q20")) {
+        env_set("FORCE_VERSION", "q20");
+    } else {
+        env_set("FORCE_VERSION", "q90");
+    }
         env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
         writeScreenReg = 0x2c;
         madctlCmd = 0xB0;
@@ -300,14 +307,6 @@ static uint8_t readID(void) {
         madctlCmd = 0xB0;
         invert = 0x20;
         return 2;
-    }
-    if (console_variant && !strcmp(console_variant, "xyc")) {
-        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
-        env_set("CONSOLE_PARAMETERS", "");
-        env_set("FORCE_VERSION", "xyc");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
-        writeScreenReg = 0x2c;
-        return 4;
     }
 
    // Autodetection method if no valid CONSOLE_VARIANT provided within cnofiguration file in SD

--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -190,10 +190,10 @@ static uint8_t readID(void) {
         invert = 0x20;
         return 2;
     }
-    if (console_variant && !strcmp(console_variant, "m3")) {
+    if (console_variant && !strcmp(console_variant, "m3_r61520")) {
         env_set("CONSOLE_VIDEO", "r61520fb.ko");
         env_set("CONSOLE_PARAMETERS", "version=1 flip=1 invert=1 lowcurrent=1");
-        env_set("FORCE_VERSION", "m3");
+        env_set("FORCE_VERSION", "m3_r61520");
         env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
         writeScreenReg = 0x2c;
         madctlCmd = 0x38;
@@ -224,13 +224,23 @@ static uint8_t readID(void) {
         writeScreenReg = 0x2c;
         return 4;
     }
-    if (console_variant && !strcmp(console_variant, "xyc")) {
+    if (console_variant && !strcmp(console_variant, "xyc_gc9306")) {
         env_set("CONSOLE_VIDEO", "gc9306fb.ko");
         env_set("CONSOLE_PARAMETERS", "");
-        env_set("FORCE_VERSION", "xyc");
+        env_set("FORCE_VERSION", "xyc_gc9306");
         env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
         writeScreenReg = 0x2c;
         return 4;
+    }
+    if (console_variant && !strcmp(console_variant, "pocketgo")) {
+        env_set("CONSOLE_VIDEO", "st7789sfb.ko");
+        env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
+        env_set("FORCE_VERSION", "pocketgo");
+        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+        writeScreenReg = 0x2c;
+        madctlCmd = 0xB0;
+        invert = 0x20;
+        return 2;
     }
     if (console_variant && !strcmp(console_variant, "pocketgo_TE")) {
         env_set("CONSOLE_VIDEO", "st7789sTEfb.ko");
@@ -246,21 +256,11 @@ static uint8_t readID(void) {
         env_set("CONSOLE_VIDEO", "st7789sfb.ko");
         env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
         if (console_variant && !strcmp(console_variant, "q20")) {
-        env_set("FORCE_VERSION", "q20");
-    } else {
-        env_set("FORCE_VERSION", "q90");
-    }
+            env_set("FORCE_VERSION", "q20");
+        } else {
+            env_set("FORCE_VERSION", "q90");
+        }
         env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-        writeScreenReg = 0x2c;
-        madctlCmd = 0xB0;
-        invert = 0x20;
-        return 2;
-    }
-    if (console_variant && !strcmp(console_variant, "pocketgo")) {
-        env_set("CONSOLE_VIDEO", "st7789sfb.ko");
-        env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
-        env_set("FORCE_VERSION", "pocketgo");
-        env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
         writeScreenReg = 0x2c;
         madctlCmd = 0xB0;
         invert = 0x20;
@@ -329,7 +329,7 @@ static uint8_t readID(void) {
         return 1;
     }
     if ((ver[1] == 0x85) && (ver[2] == 0x85) && (ver[3] == 0x52)) { // ST7789S controller
-        if (console_variant && !strcmp(console_variant, "bittboy2x_v1")) { //bb2x
+        if (console_variant && !strcmp(console_variant, "bittboy")) { //bb2x
             madctlCmd = 0xe0;
             invert = 0x20;
             writeScreenReg = 0x2c;
@@ -340,32 +340,23 @@ static uint8_t readID(void) {
             return 1;
         }
         miyoo_ver = 2;
-        if ((console_variant && !strcmp(console_variant, "bittboy3.5")) || (console_variant && !strcmp(console_variant, "bittboy2x_v2"))) {
+        if ((console_variant && !strcmp(console_variant, "bittboy3")) || (console_variant && !strcmp(console_variant, "bittboy2"))) {
             madctlCmd = 0x70;
             env_set("DETECTED_VERSION", "bittboy3.5/bittboy2x_v2 ST7789S controller");
             env_set("CONSOLE_PARAMETERS", "lowcurrent=1 flip=1");
-            if (!strcmp(console_variant, "bittboy3.5"))
+            if (!strcmp(console_variant, "bittboy3"))
                 env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
             else
                 env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1");
-        }
-        else {
+        } else {
             madctlCmd = 0xB0;
             env_set("DETECTED_VERSION", "V90/Q90/Q20/PocketGo ST7789S controller");
             env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
-            if (!strcmp(console_variant, "q20") || !strcmp(console_variant, "q90"))
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-            else if (!strcmp(console_variant, "v90"))
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=5 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
-            else
-                env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
+            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1");
         }
         invert = 0x20;
         writeScreenReg = 0x2c;
-        if (console_variant && !strcmp(console_variant, "pocketgo_TE"))
-            env_set("CONSOLE_VIDEO", "st7789sTEfb.ko");
-        else
-            env_set("CONSOLE_VIDEO", "st7789sfb.ko");
+        env_set("CONSOLE_VIDEO", "st7789sfb.ko");
         return 2;
     }
     if ((ver[2] == 0xC5) && (ver[3] == 0x05)) { // R61505W controller
@@ -378,21 +369,10 @@ static uint8_t readID(void) {
         writeScreenReg = 0x2c;
         return 3;
     }
-    if ((ver[2] == 0x93) && (ver[3] == 0x06)) { // GC9306 controller
+    if ((ver[2] == 0x93) && ((ver[3] == 0x06) || (ver[3] == 0x05))) { // GC9306 or GC9305 controller
         env_set("CONSOLE_VIDEO", "gc9306fb.ko");
         env_set("CONSOLE_PARAMETERS", "");
-        env_set("DETECTED_VERSION", "GC9306 controller");
-        if (!strcmp(console_variant, "xyc"))
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
-        else
-            env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1");
-        writeScreenReg = 0x2c;
-        return 4;
-    }
-    if ((ver[2] == 0x93) && (ver[3] == 0x05)) { // GC9305 controller
-        env_set("CONSOLE_VIDEO", "gc9306fb.ko");
-        env_set("CONSOLE_PARAMETERS", "");
-        env_set("DETECTED_VERSION", "GC9305 controller");
+        env_set("DETECTED_VERSION", "GC9306/GC9305 controller from gc9306fb");
         if (!strcmp(console_variant, "xyc"))
             env_set("bootcmd_args", "setenv bootargs console=tty0 console=ttyS1,115200 panic=5 rootwait root=/dev/mmcblk0p2 rw miyoo_kbd.miyoo_ver=4 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=3");
         else


### PR DESCRIPTION
- reorder between FORCE_VERSION and DETECTED_VERSION when it kicks in our autodetection method.
- separate FORCE and DETECED variants & cleanup readID
  - add "m3_gc9306" force variant
  - add "m3_r61520" and "xyc_gc9306" to forced variants (from old xyc and m3, move them to detectd var.)
  - rm v90/q90/q20/pgo from detected variants
- unify GC9306/GC9305 controller