### PR TITLE
[DRAM_SUNIV] correct `m=m_factor+1` enumerations

### DIFF
--- a/arch/arm/mach-sunxi/dram_suniv.c
+++ b/arch/arm/mach-sunxi/dram_suniv.c
@@ -446,14 +446,31 @@ static void do_dram_init(struct dram_para * para)
 		writel(0xc440cccc, &ccm->pll5_pattern_cfg);
 	}
 
-	if((para->clk) <= 96)
+	if ((para->clk) < 96)
+	{
 		m = 2;
+	} 
+	else 
+	{
+		if ((para->clk) % 2)
+			m = 4;
+		else if ((para->clk) % 3)
+			m = 3;
+		else if((para->clk) % (3*4))
+			m = 2;
+		else
+			m = 1;
+	}
+	val = CCM_PLL5_CTRL_EN | CCM_PLL5_CTRL_UPD;
+	if (m == 4)
+		val |= CCM_PLL5_CTRL_N((para->clk * 2 / 3) / (24 / m)) |
+			   CCM_PLL5_CTRL_K(3) | CCM_PLL5_CTRL_M(m);
+	else if (m == 3)
+		val |= CCM_PLL5_CTRL_N((para->clk) / (24 / m)) |
+			   CCM_PLL5_CTRL_K(2) | CCM_PLL5_CTRL_M(m);
 	else
-		m = 1;
-
-	val = CCM_PLL5_CTRL_EN | CCM_PLL5_CTRL_UPD |
-	      CCM_PLL5_CTRL_N((para->clk * 2) / (24 / m)) |
-	      CCM_PLL5_CTRL_K(1) | CCM_PLL5_CTRL_M(m);
+		val |= CCM_PLL5_CTRL_N((para->clk * 2) / (24 / m)) |
+			   CCM_PLL5_CTRL_K(1) | CCM_PLL5_CTRL_M(m);
 	if(para->cas & GENMASK(7, 4))
 	{
 		val |= CCM_PLL5_CTRL_SIGMA_DELTA_EN;

--- a/arch/arm/mach-sunxi/dram_suniv.c
+++ b/arch/arm/mach-sunxi/dram_suniv.c
@@ -420,7 +420,7 @@ static void do_dram_init(struct dram_para * para)
 		setbits_le32(SUNXI_PIO_BASE + 0x2c4, (0x1 << 23) | (0x20 << 17));
 	}
 
-	if((para->clk >= 144) && (para->clk <= 180))
+	if((para->clk >= 144) && (para->clk < 180))
 	{
 		writel(0xaaa, SUNXI_PIO_BASE + 0x2c0);
 	}
@@ -449,8 +449,8 @@ static void do_dram_init(struct dram_para * para)
 	if ((para->clk) < 96)
 	{
 		m = 2;
-	} 
-	else 
+	}
+	else
 	{
 		if ((para->clk) % 2)
 			m = 4;


### PR DESCRIPTION
Holy moly! The uboot upstream code doesn't allow for PLL_DDR outputs with divisors (mostly) other than `1`, so 174MHz is not applicable by default (it just reverts to 168).

List with correct values (after change) for [ddr_clock](https://github.com/Apaczer/miyoo_tools/tree/main/ddr_clock):
```
96,102,104,108,112,114,120,126,128,132,136,138,144,150,152,156,160,162,168,174,176,180,184,186,192,198,200,204,208,216,224,228,232,234,240,248,252,256,264,270,272,276,288,300,
```
Personally I have found the 198MHz to be max stable and 204 the bleeding edge.