### PR TITLE
setenv, use '+' instead ' ' to pass video driver

### DIFF
--- a/drivers/video/sunxi/sunxi_display.c
+++ b/drivers/video/sunxi/sunxi_display.c
@@ -193,7 +193,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "r61520fb.ko");
 		env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
 		env_set("FORCE_VERSION", "bittboy2x_v1");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=1 miyoo-video.driver='r61520fb version=1 lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=1 miyoo-video.driver='r61520fb+version=1+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0xe0;
 		invert = 0x20;
@@ -203,7 +203,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "st7789sfb.ko");
 		env_set("CONSOLE_PARAMETERS", "flip=1 lowcurrent=1");
 		env_set("FORCE_VERSION", "bittboy2x_v2");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb flip=1 lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+flip=1+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0x70;
 		invert = 0x20;
@@ -213,7 +213,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "st7789sfb.ko");
 		env_set("CONSOLE_PARAMETERS", "flip=1 lowcurrent=1");
 		env_set("FORCE_VERSION", "bittboy3.5");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb flip=1 lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+flip=1+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0x70;
 		invert = 0x20;
@@ -223,7 +223,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "r61520fb.ko");
 		env_set("CONSOLE_PARAMETERS", "version=1 flip=1 invert=1 lowcurrent=1");
 		env_set("FORCE_VERSION", "m3_r61520");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1 miyoo-video.driver='r61520fb version=1 flip=1 invert=1 lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1 miyoo-video.driver='r61520fb+version=1+flip=1+invert=1+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0x38;
 		invert = 0x21;
@@ -265,7 +265,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "st7789sfb.ko");
 		env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
 		env_set("FORCE_VERSION", "pocketgo");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0xB0;
 		invert = 0x20;
@@ -288,7 +288,7 @@ static uint8_t readID(void) {
 			env_set("FORCE_VERSION", "q20");
 		else
 			env_set("FORCE_VERSION", "q90");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=6 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0xB0;
 		invert = 0x20;
@@ -298,7 +298,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "st7789sfb.ko");
 		env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
 		env_set("FORCE_VERSION", "v90");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=5 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=5 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+lowcurrent=1'");
 		writeScreenReg = 0x2c;
 		madctlCmd = 0xB0;
 		invert = 0x20;
@@ -350,7 +350,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "r61520fb.ko");
 		env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
 		env_set("DETECTED_VERSION", "R61520 controller");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=1 miyoo-video.driver='r61520fb version=1 lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=1 miyoo-video.driver='r61520fb version=1+lowcurrent=1'");
 		madctlCmd = 0xe0;
 		invert = 0x20;
 		writeScreenReg = 0x2c;
@@ -364,7 +364,7 @@ static uint8_t readID(void) {
 			env_set("CONSOLE_VIDEO", "r61520fb.ko");
 			env_set("CONSOLE_PARAMETERS", "version=1 lowcurrent=1");
 			env_set("DETECTED_VERSION", "bittboy2x_v1 r61520fb controller");
-			env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=1 miyoo-video.driver='r61520fb version=1 lowcurrent=1'");
+			env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=1 miyoo-video.driver='r61520fb+version=1+lowcurrent=1'");
 			return 1;
 		}
 		miyoo_ver = 2;
@@ -373,14 +373,14 @@ static uint8_t readID(void) {
 			env_set("DETECTED_VERSION", "bittboy3.5/bittboy2x_v2 ST7789S controller");
 			env_set("CONSOLE_PARAMETERS", "lowcurrent=1 flip=1");
 			if (!strcmp(console_variant, "bittboy3"))
-				env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb lowcurrent=1 flip=1'");
+				env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=7 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+lowcurrent=1+flip=1'");
 			else
-				env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb lowcurrent=1 flip=1'");
+				env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=3 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+lowcurrent=1+flip=1'");
 		} else {
 			madctlCmd = 0xB0;
 			env_set("DETECTED_VERSION", "V90/Q90/Q20/PocketGo ST7789S controller");
 			env_set("CONSOLE_PARAMETERS", "lowcurrent=1");
-			env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb lowcurrent=1'");
+			env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 pwm-suniv.motor_ver=2 miyoo-video.driver='st7789sfb+lowcurrent=1'");
 		}
 		invert = 0x20;
 		writeScreenReg = 0x2c;
@@ -391,7 +391,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "r61520fb.ko");
 		env_set("CONSOLE_PARAMETERS", "version=3");
 		env_set("DETECTED_VERSION", "R61505W controller");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 miyoo-video.driver='r61520fb version=3'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=2 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 miyoo-video.driver='r61520fb+version=3'");
 		madctlCmd = 0xB0;
 		invert = 0x20;
 		writeScreenReg = 0x2c;
@@ -412,7 +412,7 @@ static uint8_t readID(void) {
 		env_set("CONSOLE_VIDEO", "r61520fb.ko");
 		env_set("CONSOLE_PARAMETERS", "version=1 flip=1 invert=1 lowcurrent=1");
 		env_set("DETECTED_VERSION", "SUP M3 unknown controller Works with R61520");
-		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1 miyoo-video.driver='r61520fb version=1 flip=1 invert=1 lowcurrent=1'");
+		env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=3 miyoo_kbd.miyoo_layout=4 miyoo.miyoo_snd=2 miyoo-battery.use_charge_status=1 miyoo-video.driver='r61520fb+version=1+flip=1+invert=1+lowcurrent=1'");
 		madctlCmd = 0x38;
 		invert = 0x21;
 		writeScreenReg = 0x2c;
@@ -430,7 +430,7 @@ static uint8_t readID(void) {
 	env_set("CONSOLE_VIDEO", "r61520fb.ko");
 	env_set("CONSOLE_PARAMETERS", "debug=1");
 	env_set("DETECTED_VERSION", "UNKNOWN");
-	env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 miyoo-video.driver='r61520fb debug=1'");
+	env_set("bootcmd_args", "setenv bootargs ${bootargs} miyoo_kbd.miyoo_ver=1 miyoo_kbd.miyoo_layout=1 miyoo.miyoo_snd=1 miyoo-video.driver='r61520fb+debug=1'");
 	writeScreenReg = 0x2c;
 	madctlCmd = 0xe0;
 	invert = 0x20;


### PR DESCRIPTION
quotes are ignored by setenv, so use '+' instead ' ' to pass video driver parameters